### PR TITLE
Fix and update macOS support, comply with calls deprecated in C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,18 @@ if(NOT ${PROTOBUF_FOUND} OR ${CMAKE_VERSION} VERSION_LESS 3.6.0 OR NOT TARGET pr
     include(BuildProtobuf)
 endif()
 
+# Try to auto-locate Qt5 on MacOS (won't work with custom installs)
+if (APPLE)
+    if (EXISTS /usr/local/opt/qt@5)
+        set(Qt5_DIR "/usr/local/opt/qt@5/lib/cmake/Qt5")
+    elseif(EXISTS /usr/local/opt/qt5)
+        set(Qt5_DIR "/usr/local/opt/qt5/lib/cmake/Qt5")
+    else()
+        message(FATAL_ERROR "Could not find Qt5. Please install with `brew install qt@5`.")
+    endif()
+endif()
+
+
 set(CMAKE_AUTOMOC ON)
 find_package(Qt5 COMPONENTS Core Widgets Network OpenGL REQUIRED)
 

--- a/COMPILE.md
+++ b/COMPILE.md
@@ -31,7 +31,7 @@ Certain features require additional libraries:
   * [Setup](#setup)
   * [Compiling](#compiling)
   * [Common problems](#common-problems)
-- [Mac OS X](#mac-os-x)
+- [MacOS](#macos)
 
 ## Note for Robocup 2021 participants
 None of the additional libraries are required to use the simulator. You'll
@@ -199,27 +199,26 @@ the following steps:
 - Open the device manager and choose to manually select a driver for the transceiver.
   Then select the folder containing the `winusbcompat.inf`.
 
-## Mac OS X
-Get dependencies using [Homebrew](http://brew.sh):
-```
-brew install cmake git sdl2 protobuf libusb python@2
-```
-Install Xcode from the macOS App Store.
-Then run the following command to install the Command Line Developer Tools if prompted to do so.
+## MacOS
+Homebrew requires Xcode and Command Line Utilities. 
+
+Install Xcode from the App Store, run it once and then install the utilities with:
 ```
 xcode-select --install
 ```
-Run Xcode once afterwards to ensure that everything gets setup. Starting Xcode may also be necessary after an update.
 
-Download Qt 5 from http://qt-project.org and install it.
-WARNING: **DO NOT** install `Qt 5.4.0-5.5.0`; `Qt 5.5.1` is ok
+Get dependencies using [Homebrew](http://brew.sh):
+
+```
+brew install cmake git sdl2 protobuf libusb python@2 qt@5
+```
 
 Build using:
 ```
 $ cd path/to/framework
 $ libs/v8/build.sh
 $ mkdir build-mac && cd build-mac
-$ cmake -DCMAKE_PREFIX_PATH=~/Qt/5.6/clang_64/lib/cmake -DCMAKE_BUILD_TYPE=Release ..
+$ cmake -DCMAKE_BUILD_TYPE=Release ..
 $ make
 ```
 

--- a/COMPILE.md
+++ b/COMPILE.md
@@ -31,7 +31,7 @@ Certain features require additional libraries:
   * [Setup](#setup)
   * [Compiling](#compiling)
   * [Common problems](#common-problems)
-- [MacOS](#macos)
+- [macOS](#macos)
 
 ## Note for Robocup 2021 participants
 None of the additional libraries are required to use the simulator. You'll
@@ -199,7 +199,7 @@ the following steps:
 - Open the device manager and choose to manually select a driver for the transceiver.
   Then select the folder containing the `winusbcompat.inf`.
 
-## MacOS
+## macOS
 Homebrew requires Xcode and Command Line Utilities. 
 
 Install Xcode from the App Store, run it once and then install the utilities with:

--- a/cmake/BuildSourceMap.cmake
+++ b/cmake/BuildSourceMap.cmake
@@ -24,18 +24,20 @@ include(ExternalProjectHelper)
 set(LIBSM_SUBPATH "bin/${CMAKE_STATIC_LIBRARY_PREFIX}SourceMap${CMAKE_STATIC_LIBRARY_SUFFIX}")
 find_package(Qt5 COMPONENTS Core REQUIRED)
 
+set(SOURCEMAP_PATCH_FILE ${CMAKE_CURRENT_LIST_DIR}/sourcemap.patch)
 ExternalProject_Add(project_sourcemap
     # from https://github.com/hicknhack-software/SourceMap-Qt.git
     URL http://www.robotics-erlangen.de/downloads/libraries/SourceMap-Qt-1.0.1.tar.gz
     URL_HASH SHA256=833ca5e1efa6f58ed69188c5cff1a9aaf493bd50785bc220ff200bc7c717ce3f
     DOWNLOAD_NO_PROGRESS true
+    PATCH_COMMAND cat ${SOURCEMAP_PATCH_FILE} | patch -p1
     CONFIGURE_COMMAND ${Qt5Core_QMAKE_EXECUTABLE} "CONFIG+=NoTest" <SOURCE_DIR>
     BUILD_BYPRODUCTS
         "<BINARY_DIR>/${LIBSM_SUBPATH}"
     INSTALL_COMMAND ""
 )
 EPHelper_Add_Cleanup(project_sourcemap bin include lib share)
-EPHelper_Add_Clobber(project_sourcemap ${CMAKE_CURRENT_LIST_DIR}/stub.patch)
+EPHelper_Add_Clobber(project_sourcemap ${SOURCEMAP_PATCH_FILE})
 EPHelper_Mark_For_Download(project_sourcemap)
 
 externalproject_get_property(project_sourcemap binary_dir source_dir)

--- a/cmake/sourcemap.patch
+++ b/cmake/sourcemap.patch
@@ -1,0 +1,22 @@
+--- a/src/SourceMap/Mapping_impl.h
++++ b/src/SourceMap/Mapping_impl.h
+@@ -101,7 +101,7 @@
+         for (auto& entry : m_data.entries) {
+             if (entry.original.name.isEmpty()) continue;
+             if (std::none_of(m_originalNames.begin(), m_originalNames.end(),
+-                             std::bind1st(std::equal_to<QString>(), entry.original.name))) {
++                             std::bind(std::equal_to<QString>(), entry.original.name))) {
+                 m_originalNames.push_back(entry.original.name);
+             }
+         }
+--- a/src/SourceMap/RevisionThree_impl.h
++++ b/src/SourceMap/RevisionThree_impl.h
+@@ -71,7 +71,7 @@
+     for (auto& entry : extractEntryList(mapping)) {
+         if (entry.name.isEmpty()) continue;
+         if (std::none_of(names.begin(), names.end(),
+-                         std::bind1st(std::equal_to<QString>(), entry.name))) {
++                         std::bind(std::equal_to<QString>(), entry.name))) {
+             names.push_back(entry.name);
+         }
+     }

--- a/cmake/sourcemap.patch
+++ b/cmake/sourcemap.patch
@@ -5,7 +5,7 @@
              if (entry.original.name.isEmpty()) continue;
              if (std::none_of(m_originalNames.begin(), m_originalNames.end(),
 -                             std::bind1st(std::equal_to<QString>(), entry.original.name))) {
-+                             std::bind(std::equal_to<QString>(), entry.original.name))) {
++                             std::bind(std::equal_to<QString>(), entry.original.name, std::placeholders::_1))) {
                  m_originalNames.push_back(entry.original.name);
              }
          }
@@ -16,7 +16,7 @@
          if (entry.name.isEmpty()) continue;
          if (std::none_of(names.begin(), names.end(),
 -                         std::bind1st(std::equal_to<QString>(), entry.name))) {
-+                         std::bind(std::equal_to<QString>(), entry.name))) {
++                         std::bind(std::equal_to<QString>(), entry.name, std::placeholders::_1))) {
              names.push_back(entry.name);
          }
      }

--- a/libs/v8/build.sh
+++ b/libs/v8/build.sh
@@ -105,11 +105,11 @@ fi
 
 cd v8
 
+function fakeuser {
+    git config user.name "patch"
+    git config user.email "noreply@robotics-erlangen.de"
+}
 if [[ "$IS_MINGW" == 1 ]]; then
-    function fakeuser {
-        git config user.name "patch"
-        git config user.email "noreply@robotics-erlangen.de"
-    }
     if [[ ! -e .patched || "$(cat .patched)" != "$V8_BASE_REVISION" ]]; then
         function v8base {
             git checkout $V8_BASE_REVISION
@@ -152,6 +152,19 @@ else
         git checkout $V8_BASE_REVISION
     fi
     gclient sync
+
+    cd build
+    if [[ ! -e .patched || "$(cat .patched)" != "$V8_BASE_REVISION" ]]; then
+        function buildbase {
+            git checkout $BUILD_REVISION
+        }
+        trap buildbase EXIT
+        buildbase
+        fakeuser
+        git am ../../patches/0001-macos-sdk-search.patch
+        trap '-' EXIT
+    fi
+    cd ..
 fi
 
 if [[ "$IS_MINGW32" == 1 ]]; then

--- a/libs/v8/patches/0001-macos-sdk-search.patch
+++ b/libs/v8/patches/0001-macos-sdk-search.patch
@@ -1,0 +1,25 @@
+From ced8d9e522dc8b6a84fc8b730c9ff719c82c463e Mon Sep 17 00:00:00 2001
+From: Michael Eischer <michael.eischer@robotics-erlangen.de>
+Date: Mon, 2 Aug 2021 21:58:44 +0200
+Subject: [PATCH] Fix macOS 11.x SDK detection
+
+---
+ mac/find_sdk.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/mac/find_sdk.py b/mac/find_sdk.py
+index 540a3202e..89669d01b 100755
+--- a/mac/find_sdk.py
++++ b/mac/find_sdk.py
+@@ -69,7 +69,7 @@ def main():
+     raise SdkError('Install Xcode, launch it, accept the license ' +
+       'agreement, and run `sudo xcode-select -s /path/to/Xcode.app` ' +
+       'to continue.')
+-  sdks = [re.findall('^MacOSX(10\.\d+)\.sdk$', s) for s in os.listdir(sdk_dir)]
++  sdks = [re.findall('^MacOSX(1[01]\.\d+)\.sdk$', s) for s in os.listdir(sdk_dir)]
+   sdks = [s[0] for s in sdks if s]  # [['10.5'], ['10.6']] => ['10.5', '10.6']
+   sdks = [s for s in sdks  # ['10.5', '10.6'] => ['10.6']
+           if parse_version(s) >= parse_version(min_sdk_version)]
+-- 
+2.32.0
+

--- a/src/amun/simulator/include/simulator/simulator.h
+++ b/src/amun/simulator/include/simulator/simulator.h
@@ -30,6 +30,7 @@
 #include <QQueue>
 #include <QByteArray>
 #include <tuple>
+#include <random>
 
 // higher values break the rolling friction of the ball
 const float SIMULATOR_SCALE = 10.0f;
@@ -125,6 +126,8 @@ private:
     qint64 m_lastBallSendTime = 0;
     std::map<qint64, unsigned> m_lastFrameNumber;
     ErrorAggregator *m_aggregator;
+
+    std::mt19937 rand_shuffle_src = std::mt19937(std::random_device()());
 };
 
 #endif // SIMULATOR_H

--- a/src/amun/simulator/simulator.cpp
+++ b/src/amun/simulator/simulator.cpp
@@ -467,7 +467,7 @@ std::tuple<QList<QByteArray>, QByteArray, qint64> Simulator::createVisionPacket(
 
         // if multiple balls are reported, shuffle them randomly (the tracking might have systematic errors depending on the ball order)
         if (frame.balls_size() > 1) {
-            std::random_shuffle(frame.mutable_balls()->begin(), frame.mutable_balls()->end());
+            std::shuffle(frame.mutable_balls()->begin(), frame.mutable_balls()->end(), rand_shuffle_src);
         }
 
         SSL_WrapperPacket packet;


### PR DESCRIPTION
- The simulator-cli build used to fail on MacOS 11.4 due to the deprecation of std::random_shuffle in C++17.
   This has been remedied by replacing the call with a call to std::shuffle.

- According to the documentation, Qt5.5.1+ is acceptable. It is now possible to install Qt5.15.2 via Homebrew (`brew install qt@5`). This places an acceptable Qt version in a predictable location and therefore Qt installation and discovery can be automated. Qt5 search paths were added to CMake.

- Documentation was updated to recommend installation of Qt5 via Homebrew, steps were removed and reordered to reflect that Homebrew requires Xcode and Command Line Tools.