### PR TITLE
Added possiblity for simulator to output to localhost (127.0.0.1), in addition to broadcast (224.5.23.2)

### DIFF
--- a/src/core/include/core/sslprotocols.h
+++ b/src/core/include/core/sslprotocols.h
@@ -29,12 +29,14 @@
  * address:port
  */
 constexpr const char* SSL_GAME_CONTROLLER_ADDRESS = "224.5.23.1";
+constexpr const char* SSL_GAME_CONTROLLER_ADDRESS_LOCALHOST = "127.0.0.1";
 constexpr const uint16_t SSL_GAME_CONTROLLER_PORT = 10003;
 
 /* SSL vision publishes vision detections using UDP multicast on this
  * address:port
  */
 constexpr const char* SSL_VISION_ADDRESS = "224.5.23.2";
+constexpr const char* SSL_VISION_ADDRESS_LOCALHOST = "127.0.0.1";
 constexpr const uint16_t SSL_VISION_PORT = 10006;
 
 /* A simulator will publish vision data using this port instead of
@@ -54,6 +56,7 @@ constexpr const uint16_t SSL_TEAM_TO_GC_PORT = 10008;
  * this address:port
  */
 constexpr const char* SSL_VISION_TRACKER_ADDRESS = "224.5.23.2";
+constexpr const char* SSL_VISION_TRACKER_ADDRESS_LOCALHOST = "127.0.0.1";
 constexpr const uint16_t SSL_VISION_TRACKER_PORT = 10010;
 
 /* A simulator will listen for simulation control commands (e.g ball

--- a/src/simulator/simulator.cpp
+++ b/src/simulator/simulator.cpp
@@ -81,8 +81,10 @@ static void CHECK_PRINTF log(FILE* stream, const char* fmt, ...) {
 class SSLVisionServer: public QObject {
     Q_OBJECT
 public:
-    SSLVisionServer(int port);
+    SSLVisionServer(int port, const string &net_address);
     void setPort(int port);
+    void setNetAddress(const string &net_address);
+
 
 public slots:
     void sendVisionData(const QByteArray& data, qint64 time, QString sender);
@@ -567,7 +569,7 @@ void RobotCommandAdaptor::sendRobotRespose(const sslsim::RobotControlResponse& o
 }
 
 
-SSLVisionServer::SSLVisionServer(int port): m_server(this, port)
+SSLVisionServer::SSLVisionServer(int port, const string &net_address): m_server(this, port, net_address)
 {
 }
 
@@ -578,6 +580,10 @@ void SSLVisionServer::sendVisionData(const QByteArray& data, qint64, QString)
 
 void SSLVisionServer::setPort(int port) {
     m_server.change_port(port);
+}
+
+void SSLVisionServer::setNetAddress(const string &net_address) {
+    m_server.change_address(net_address);
 }
 
 using camun::simulator::Simulator;
@@ -697,7 +703,7 @@ int main(int argc, char* argv[])
     Timer timer;
     RobotCommandAdaptor blue{true, &timer}, yellow{false, &timer};
     SimProxy sim{&timer};
-    SSLVisionServer vision{SSL_SIMULATED_VISION_PORT};
+    SSLVisionServer vision{SSL_SIMULATED_VISION_PORT, SSL_VISION_ADDRESS};
     SimulatorCommandAdaptor commands{&timer, &vision};
 
     blue.connect(&blue, &RobotCommandAdaptor::sendRadioCommands, &sim, &SimProxy::handleRadioCommands);

--- a/src/simulator/simulator.cpp
+++ b/src/simulator/simulator.cpp
@@ -27,6 +27,7 @@
 #include <cmath>
 #include <cstdio>
 #include <cstdarg>
+#include <optional>
 
 #include "protobuf/ssl_simulation_robot_control.pb.h"
 #include "protobuf/ssl_simulation_robot_feedback.pb.h"
@@ -677,9 +678,10 @@ int main(int argc, char* argv[])
 
     QCommandLineOption geometryConfig({"g", "geometry"}, "The geometry file to load as default", "file", "2020");
     QCommandLineOption realismConfig("realism", "Simulator realism configuration (short file name without the .txt)", "realism", "Realistic");
+    QCommandLineOption localhostConfig("localhost", "Use localhost as the output address for the simulator");
     parser.addOption(geometryConfig);
     parser.addOption(realismConfig);
-
+    parser.addOption(localhostConfig);
 
     parser.process(app);
 
@@ -703,7 +705,7 @@ int main(int argc, char* argv[])
     Timer timer;
     RobotCommandAdaptor blue{true, &timer}, yellow{false, &timer};
     SimProxy sim{&timer};
-    SSLVisionServer vision{SSL_SIMULATED_VISION_PORT, SSL_VISION_ADDRESS};
+    SSLVisionServer vision{SSL_SIMULATED_VISION_PORT, parser.isSet(localhostConfig) ? SSL_VISION_ADDRESS_LOCALHOST : SSL_VISION_ADDRESS};
     SimulatorCommandAdaptor commands{&timer, &vision};
 
     blue.connect(&blue, &RobotCommandAdaptor::sendRadioCommands, &sim, &SimProxy::handleRadioCommands);

--- a/src/simulator/ssl_robocup_server.h
+++ b/src/simulator/ssl_robocup_server.h
@@ -24,6 +24,7 @@
 #include <string>
 #include <QMutex>
 #include <QObject>
+#include "core/sslprotocols.h"
 using namespace std;
 
 class QUdpSocket;
@@ -36,7 +37,7 @@ friend class MultiStackRoboCupSSL;
 public:
     RoboCupSSLServer(QObject *parent=0,
                      const quint16 &port=10002,
-                     const string &net_address="224.5.23.2"
+                     const string &net_address=SSL_VISION_ADDRESS
                      );
 
     ~RoboCupSSLServer();


### PR DESCRIPTION
## The problem
It's fun here, currently at the RoboCup. Nice and cozy with 200 other people on the same network. I would like to test our software with my favorite simulator (this one). However, everyone is spamming their simulator output over the network. The simulator currently doesn't have an option to output to localhost so I can't test my software. 

**Can I simply disable my WiFi / unplug my ethernet cables?**
No. Since it broadcasts to `224.5.23.2`, some kind of network connection is required. You will see the following:
```
...
Sending UDP datagram failed (maybe too large?). Size was: 1323 byte(s).
Sending UDP datagram failed (maybe too large?). Size was: 394 byte(s).
Sending UDP datagram failed (maybe too large?). Size was: 1323 byte(s).
...
```

## The solution
Add a `--localhost` flag to the simulator, so that the simulator outputs to localhost `127.0.0.1`. Unplug all your cables, disable your wifi, and run `simulator-cli --localhost`. All other software can still listen on `224.5.23.2` and it will work fine. 